### PR TITLE
add allowed values for attributes

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -340,6 +340,11 @@ const startServer = async () => {
                     'Creates a new `Recipient`. object and verifies the recipient’s identity. Also verifies the recipient’s bank account information or debit card, if either is provided.'
                 ],
                 tags: ['api'],
+                validate: {
+                  query: {
+                    type: Joi.string().only('bank', 'card').description('Account type').required()
+                  }
+                },
                 plugins: {
                     'hapi-docs': {
                         order: 1

--- a/examples/server.js
+++ b/examples/server.js
@@ -216,6 +216,13 @@ const startServer = async () => {
                 notes:
                     'Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.',
                 tags: ['api'],
+                validate: {
+                  query: {
+                    verification: Joi.array().items(
+                        Joi.string().only([ 'verified', 'pending', 'unverified', 'investigate', 'more', 'required', 'question', 'specialist', 'check', 'unknown', 'restricted', 'cancelled' ])
+                    ).single().optional().description('Restrict results to these verification states')
+                  }
+                },
                 plugins: {
                     'hapi-docs': {
                         order: 5

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -79,6 +79,19 @@ class Paths {
             paramsData.children = children
         }
 
+        if (paramsData.type === 'array') {
+          let items = []
+
+          if (param.items) {
+            items = param.items.map(i => ({
+                type: i.type,
+                valids: i.valids
+            }))
+          }
+
+          paramsData.items = items
+        }
+
         return paramsData
     }
 }

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -57,6 +57,7 @@ class Paths {
             notes: this.processNotes(param.notes),
             tags: param.tags,
             type: param.type,
+            valids: param.valids,
             flags: param.flags && {
                 required: param.flags.presence === 'required',
                 default: Hoek.reach(param.flags.default, 'description', {

--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -173,6 +173,15 @@
                                             >optional<template v-if="param.flags && param.flags.default">, default is <span class="method__list__item__label__promote">{{ param.flags.default }}</span></template></span>
                                         </h3>
                                         <Marked class="method__list__item__description">{{ param.description }}</Marked>
+                                        <div
+                                            v-if="param.valids"
+                                            class="method__list__item__valids__label">
+                                            <p>Allows:
+                                              <ul class="method__list__item__valids__list">
+                                                  <li v-for="valid in param.valids">{{ valid }}</li>
+                                              </ul>
+                                            </p>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -203,6 +212,15 @@
                                             >optional<template v-if="param.flags && param.flags.default">, default is <span class="method__list__item__label__promote">{{ param.flags.default }}</span></template></span>
                                         </h3>
                                         <Marked class="method__list__item__description">{{ param.description }}</Marked>
+                                        <div
+                                            v-if="param.valids"
+                                            class="method__list__item__valids__label">
+                                            <p>Allows:
+                                              <ul class="method__list__item__valids__list">
+                                                  <li v-for="valid in param.valids">{{ valid }}</li>
+                                              </ul>
+                                            </p>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -233,6 +251,15 @@
                                             >optional<template v-if="param.flags && param.flags.default">, default is <span class="method__list__item__label__promote">{{ param.flags.default }}</span></template></span>
                                         </h3>
                                         <Marked class="method__list__item__description">{{ param.description }}</Marked>
+                                        <div
+                                            v-if="param.valids"
+                                            class="method__list__item__valids__label">
+                                            <p>Allows:
+                                              <ul class="method__list__item__valids__list">
+                                                  <li v-for="valid in param.valids">{{ valid }}</li>
+                                              </ul>
+                                            </p>
+                                        </div>
                                     </li>
                                 </ul>
                             </div>
@@ -606,7 +633,8 @@ export default {
     }
 }
 
-.method__list__item__description {
+.method__list__item__description,
+.method__list__item__valids__label {
     @include respond-to(large-screens) {
         position: relative;
         z-index: z-index(above);
@@ -625,9 +653,41 @@ export default {
     }
 
     p {
+        display: flex;
         font-size: 14px !important;
         line-height: 21px !important;
+
+        ul {
+          list-style-type: none;
+          display: flex;
+          flex-direction: row;
+
+          li {
+            margin: 0 3px;
+
+            &::before {
+              content: '"'
+            }
+
+            &:not(:last-child)::after {
+              content: '",'
+            }
+
+            &:last-child::after {
+              content: '"'
+            }
+          }
+        }
     }
+}
+
+.method__list__item__valids__label {
+  font-weight: 500;
+  color: #939da3;
+}
+
+.method__list__item__valids__list {
+  color: #939da3;
 }
 
 .method__example {

--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -176,9 +176,10 @@
                                         <div
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
-                                            <p>Allows:
-                                                <ul class="method__list__item__valids__list">
-                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                            <p>
+                                                <span class="method__list__item__valids__prefix">Allows:</span>
+                                                <ul class="method__list__item__valids__list option__list">
+                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -202,6 +203,7 @@
                                                 class="header-anchor"
                                             />
                                             <span>{{ param.name }}</span>
+                                            <span class="method__list__item__type">{{ param.type }}</span>
                                             <span
                                                 v-if="param.flags && param.flags.required"
                                                 class="method__list__item__label__badge"
@@ -215,9 +217,20 @@
                                         <div
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
-                                            <p>Allows:
-                                                <ul class="method__list__item__valids__list">
-                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                            <p>
+                                                <span class="method__list__item__valids__prefix">Allows:</span>
+                                                <ul class="method__list__item__valids__list option__list">
+                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
+                                                </ul>
+                                            </p>
+                                        </div>
+                                        <div
+                                            v-if="param.items"
+                                            class="method__list__item__items__type">
+                                            <p>
+                                                <span class="method__list__item__items__type__prefix">One or more of:</span>
+                                                <ul v-for="(item, index) in param.items" :key="index"  class="method__list__item__items__formats__list option__list">
+                                                    <li v-for="(valid, index2) in item.valids" :key="index2">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -254,9 +267,20 @@
                                         <div
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
-                                            <p>Allows:
-                                                <ul class="method__list__item__valids__list">
-                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                            <p>
+                                                <span>Allows:</span>
+                                                <ul class="method__list__item__valids__list option__list">
+                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
+                                                </ul>
+                                            </p>
+                                        </div>
+                                        <div
+                                            v-if="param.items"
+                                            class="method__list__item__items__type">
+                                            <p>
+                                                <span class="method__list__item__items__type__prefix">One or more of:</span>
+                                                <ul v-for="(item, index) in param.items" :key="index"  class="method__list__item__items__formats__list option__list">
+                                                    <li v-for="(valid, index2) in item.valids" :key="index2">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -602,9 +626,8 @@ export default {
     font-weight: 600;
 }
 
+.method__list__item__type,
 .method__list__item__label__badge {
-    font-size: 11px;
-    font-weight: 600;
     line-height: 20px;
 
     display: inline-block;
@@ -613,11 +636,6 @@ export default {
     padding: 0 8px;
 
     vertical-align: top;
-    text-transform: uppercase;
-
-    color: #ffae54;
-    border: 1px solid rgba(255, 174, 84, 0.5);
-    border-radius: 11px;
 
     @extend .method__list__item__label__details;
     @include respond-to(large-screens) {
@@ -627,14 +645,34 @@ export default {
 
         margin-left: 0;
         padding: 4px 0 0;
+    }
+}
 
+.method__list__item__type {
+  font-weight: 400;
+  color: #939da3
+}
+
+.method__list__item__label__badge {
+    text-transform: uppercase;
+
+    font-weight: 600;
+    font-size: 11px;
+
+    color: #ffae54;
+    border: 1px solid rgba(255, 174, 84, 0.5);
+    border-radius: 11px;
+
+    @extend .method__list__item__label__details;
+    @include respond-to(large-screens) {
         border: 0;
         border-radius: 0;
     }
 }
 
 .method__list__item__description,
-.method__list__item__valids__label {
+.method__list__item__valids__label,
+.method__list__item__items__type {
     @include respond-to(large-screens) {
         position: relative;
         z-index: z-index(above);
@@ -654,34 +692,42 @@ export default {
 
     p {
         display: flex;
+        flex-direction: column;
         font-size: 14px !important;
         line-height: 21px !important;
-
-        ul {
-          list-style-type: none;
-          display: flex;
-          flex-direction: row;
-
-          li {
-            margin: 0 3px;
-
-            &::before {
-              content: '"'
-            }
-
-            &:not(:last-child)::after {
-              content: '",'
-            }
-
-            &:last-child::after {
-              content: '"'
-            }
-          }
-        }
     }
 }
 
-.method__list__item__valids__label {
+.method__list__item__items__type__prefix,
+.method__list__item__valids__prefix {
+  font-weight: 500;
+}
+
+.option__list {
+  list-style-type: none;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+
+  li {
+    margin: 0 3px;
+
+    &::before {
+      content: '"'
+    }
+
+    &:not(:last-child)::after {
+      content: '",'
+    }
+
+    &:last-child::after {
+      content: '"'
+    }
+  }
+}
+
+.method__list__item__valids__label,
+.method__list__item__items__type {
   font-weight: 500;
   color: #939da3;
 }

--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -179,7 +179,9 @@
                                             <p>
                                                 <span class="method__list__item__valids__prefix">Allows:</span>
                                                 <ul class="method__list__item__valids__list option__list">
-                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
+                                                    <li
+                                                        v-for="(valid, index) in param.valids"
+                                                        :key="index">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -220,7 +222,9 @@
                                             <p>
                                                 <span class="method__list__item__valids__prefix">Allows:</span>
                                                 <ul class="method__list__item__valids__list option__list">
-                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
+                                                    <li
+                                                        v-for="(valid, index) in param.valids"
+                                                        :key="index">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -229,8 +233,13 @@
                                             class="method__list__item__items__type">
                                             <p>
                                                 <span class="method__list__item__items__type__prefix">One or more of:</span>
-                                                <ul v-for="(item, index) in param.items" :key="index"  class="method__list__item__items__formats__list option__list">
-                                                    <li v-for="(valid, index2) in item.valids" :key="index2">{{ valid }}</li>
+                                                <ul
+                                                    v-for="(item, index) in param.items"
+                                                    :key="index"
+                                                    class="method__list__item__items__formats__list option__list">
+                                                    <li
+                                                        v-for="(valid, index2) in item.valids"
+                                                        :key="index2">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -270,7 +279,9 @@
                                             <p>
                                                 <span>Allows:</span>
                                                 <ul class="method__list__item__valids__list option__list">
-                                                    <li v-for="(valid, index) in param.valids" :key="index">{{ valid }}</li>
+                                                    <li
+                                                        v-for="(valid, index) in param.valids"
+                                                        :key="index">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>
@@ -279,8 +290,13 @@
                                             class="method__list__item__items__type">
                                             <p>
                                                 <span class="method__list__item__items__type__prefix">One or more of:</span>
-                                                <ul v-for="(item, index) in param.items" :key="index"  class="method__list__item__items__formats__list option__list">
-                                                    <li v-for="(valid, index2) in item.valids" :key="index2">{{ valid }}</li>
+                                                <ul
+                                                    v-for="(item, index) in param.items"
+                                                    :key="index"
+                                                    class="method__list__item__items__formats__list option__list">
+                                                    <li
+                                                        v-for="(valid, index2) in item.valids"
+                                                        :key="index2">{{ valid }}</li>
                                                 </ul>
                                             </p>
                                         </div>

--- a/src/components/Content.vue
+++ b/src/components/Content.vue
@@ -177,9 +177,9 @@
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
                                             <p>Allows:
-                                              <ul class="method__list__item__valids__list">
-                                                  <li v-for="valid in param.valids">{{ valid }}</li>
-                                              </ul>
+                                                <ul class="method__list__item__valids__list">
+                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                                </ul>
                                             </p>
                                         </div>
                                     </li>
@@ -216,9 +216,9 @@
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
                                             <p>Allows:
-                                              <ul class="method__list__item__valids__list">
-                                                  <li v-for="valid in param.valids">{{ valid }}</li>
-                                              </ul>
+                                                <ul class="method__list__item__valids__list">
+                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                                </ul>
                                             </p>
                                         </div>
                                     </li>
@@ -255,9 +255,9 @@
                                             v-if="param.valids"
                                             class="method__list__item__valids__label">
                                             <p>Allows:
-                                              <ul class="method__list__item__valids__list">
-                                                  <li v-for="valid in param.valids">{{ valid }}</li>
-                                              </ul>
+                                                <ul class="method__list__item__valids__list">
+                                                    <li v-for="valid in param.valids">{{ valid }}</li>
+                                                </ul>
                                             </p>
                                         </div>
                                     </li>


### PR DESCRIPTION
This adds support for a list of `valid` or `.allow()` parameters for a path, query, or param attribute, which is essential when producing docs for third parties.